### PR TITLE
Remove explicit Rails dependency, as version varies

### DIFF
--- a/foreman_memcache.gemspec
+++ b/foreman_memcache.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 3.2.13"
   s.add_dependency "dalli"
 end


### PR DESCRIPTION
Causes problems when loading 3.2.8 otherwise.
