### PR TITLE
Remove unused deface dependency

### DIFF
--- a/foreman_memcache.gemspec
+++ b/foreman_memcache.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'dalli'
-  s.add_dependency 'deface'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rdoc'
 end


### PR DESCRIPTION
Added in 36e1b18, but no apparent usage.